### PR TITLE
removed lines 420,421

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -417,9 +417,6 @@
          in hardware. -->
     <bool name="config_setColorTransformAccelerated">true</bool>
 
-    <!-- Whether device supports double tap to wake -->
-    <bool name="config_supportDoubleTapWake">true</bool>
-
     <!-- Specifies whether the permissions needed by a legacy app should be
          reviewed before any of its components can run. A legacy app is one
          with targetSdkVersion < 23, i.e apps using the old permission model.


### PR DESCRIPTION
config_supportDoubleTapWake defined twice lines 376 and 421

device/xiaomi/libra/overlay/frameworks/base/core/res/res/values/config.xml:421: error: duplicate value for resource 'bool/config_supportDoubleTapWake'
device/xiaomi/libra/overlay/frameworks/base/core/res/res/values/config.xml:376: error: resource previously defined here.